### PR TITLE
Simply game start logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ python:
 install:
   - pip install coveralls
 
-script: 
-  coverage run --source=gamestart.py -m GameStarter.gamestart_test
+script:
+  coverage run --source=GameStarter -m GameStarter.gamestart_test
 
 after_success:
   coveralls --rcfile=.coveragerc
-

--- a/GameStarter/__init__.py
+++ b/GameStarter/__init__.py
@@ -71,7 +71,8 @@ class GameStarter:
 		return len(self.waiting_players) > 0
 
 	#Decide if a game is ready to start
-	def shouldStart(self):
+	@property
+	def should_start(self):
 		#You should start if:
 		# - the countdown has finished
 		# - no players are waiting (holding the launch)
@@ -140,7 +141,7 @@ def main():
 		starter.timeStep(0.05)
 		totTime += 0.05
 		#Decide if game can start
-		start = starter.shouldStart()
+		start = starter.should_start
 
 		#Step back four lines
 		sys.stdout.write("\x1B[4A")

--- a/GameStarter/__init__.py
+++ b/GameStarter/__init__.py
@@ -39,7 +39,7 @@ class GamePlayer:
 class GameStarter:
 
 	#Initialise game starter
-	def __init__(self, _unused_was_maxPlayers_, join_delay, total_start_delay, leave_delay):
+	def __init__(self, total_start_delay, join_delay, leave_delay):
 		self.start_delay = float(total_start_delay) - float(join_delay) #FIXME Backward compatibility...
 		self.reset()
 		def construct_player():
@@ -109,7 +109,7 @@ def main():
 	barScale = 60
 
 	#Get an instance of GameStarter with four players
-	starter = GameStarter(4, join_delay, total_start_delay, leave_delay)
+	starter = GameStarter(total_start_delay, join_delay, leave_delay)
 
 	#Print header for graphics
 	print()

--- a/GameStarter/__init__.py
+++ b/GameStarter/__init__.py
@@ -41,12 +41,12 @@ class GameStarter:
 	#Initialise game starter
 	def __init__(self, _unused_was_maxPlayers_, join_delay, total_start_delay, leave_delay):
 		self.start_delay = float(total_start_delay) - float(join_delay) #FIXME Backward compatibility...
-		self.resetAll()
+		self.reset()
 		def newPlayer():
 			return GamePlayer(join_delay, None, leave_delay)
 		self.newPlayer = newPlayer
 
-	def resetAll(self):
+	def reset(self):
 		self.players = {}
 		self.delay = self.start_delay
 

--- a/GameStarter/__init__.py
+++ b/GameStarter/__init__.py
@@ -11,14 +11,8 @@ class GamePlayer:
 		self.activeLevel = activeLevel
 		self.startLevel = startLevel
 		self.graceLevel = graceLevel
-		self.reset()
-
-	def reset(self):
-		#Start at 0 level
 		self.level = 0.0
-		#Assume button is not pushed
 		self.pushed = False
-		#Start inactive
 		self.active = False
 
 	#Take a time step, increment or decrement depending on button pushed state

--- a/GameStarter/__init__.py
+++ b/GameStarter/__init__.py
@@ -67,12 +67,15 @@ class GameStarter:
 
 	#Initialise game starter
 	def __init__(self, _unused_was_maxPlayers_, activeLevel, startLevel, graceLevel):
+		activeLevel = float(activeLevel)
+		startLevel = float(startLevel)
+		graceLevel = float(graceLevel)
 		#Raise error if startLevel or activeLevel is invalid
-		if ((type(activeLevel) != float) or (type(startLevel) != float)):
-			raise Exception('GameStarter.__init__: activeLevel must be a float greater than 0, startLevel must be a float greater than activeLevel.')
-		if ((activeLevel <= 0.0) or (startLevel <= activeLevel)):
-			raise Exception('GameStarter.__init__: activeLevel must be a float greater than 0, startLevel must be a float greater than activeLevel. (Active: %f, Start: %f)' % (activeLevel, startLevel))
-		#Create this number of players
+		if (activeLevel <= 0.0):
+			raise Exception('activeLevel must be positive')
+		if (activeLevel >= startLevel):
+			raise Exception('activeLevel must be less than startLevel')
+
 		self.resetAll()
 		def newPlayer():
 			return GamePlayer(activeLevel, startLevel, graceLevel)

--- a/GameStarter/__init__.py
+++ b/GameStarter/__init__.py
@@ -89,17 +89,12 @@ class GameStarter:
 	def playersInState(self, state):
 		return [id for id, pl in self.players.items() if pl.state == state]
 
-	#Get total number of startable players
-	def totalStartablePlayers(self):
-		return len(self.playersInState('START'))
-
 	#Decide if a game is ready to start
 	def shouldStart(self):
 		#You should start if you have:
-		# - at least two startable players
-		# - at least one player who has reached the start state
+		# - at least two players who have reached the start state
 		# - no players who have recently pressed (in)
-		return (self.totalStartablePlayers() > 1) and (self.totalInState('START') > 0) and (self.totalInState('WAIT') == 0)
+		return (self.totalInState('START') > 1) and (self.totalInState('WAIT') == 0)
 
 	def getPlayer(self, player_id):
 		if player_id not in self.players:

--- a/GameStarter/__init__.py
+++ b/GameStarter/__init__.py
@@ -42,9 +42,9 @@ class GameStarter:
 	def __init__(self, _unused_was_maxPlayers_, join_delay, total_start_delay, leave_delay):
 		self.start_delay = float(total_start_delay) - float(join_delay) #FIXME Backward compatibility...
 		self.reset()
-		def newPlayer():
+		def construct_player():
 			return GamePlayer(join_delay, leave_delay)
-		self.newPlayer = newPlayer
+		self.construct_player = construct_player
 
 	def reset(self):
 		self.players = {}
@@ -80,7 +80,7 @@ class GameStarter:
 
 	def player(self, player_id):
 		if player_id not in self.players:
-			self.players[player_id] = self.newPlayer()
+			self.players[player_id] = self.construct_player()
 		return self.players[player_id]
 
 	#Step all players by given time

--- a/GameStarter/__init__.py
+++ b/GameStarter/__init__.py
@@ -66,19 +66,12 @@ class GamePlayer:
 class GameStarter:
 
 	#Initialise game starter
-	def __init__(self, maxPlayers, activeLevel, startLevel, graceLevel):
-		#Raise error if number of players is too low
-		if type(maxPlayers) != int:
-			raise Exception('GameStarter.__init__: maxPlayers must be an integer greater than 2 (At least two players are required).')
-		if maxPlayers < 2:
-			raise Exception('GameStarter.__init__: maxPlayers must be an integer greater than 2 (At least two players are required). Attempted to init GameStarter with %d players.' % maxPlayers)
+	def __init__(self, _unused_was_maxPlayers_, activeLevel, startLevel, graceLevel):
 		#Raise error if startLevel or activeLevel is invalid
 		if ((type(activeLevel) != float) or (type(startLevel) != float)):
 			raise Exception('GameStarter.__init__: activeLevel must be a float greater than 0, startLevel must be a float greater than activeLevel.')
 		if ((activeLevel <= 0.0) or (startLevel <= activeLevel)):
 			raise Exception('GameStarter.__init__: activeLevel must be a float greater than 0, startLevel must be a float greater than activeLevel. (Active: %f, Start: %f)' % (activeLevel, startLevel))
-		#Store maximum number of players
-		self.maxPlayers = maxPlayers
 		#Create this number of players
 		self.resetAll()
 		def newPlayer():

--- a/GameStarter/__init__.py
+++ b/GameStarter/__init__.py
@@ -14,7 +14,7 @@ class GamePlayer:
 		self.delay = self.join_delay
 
 	#Take a time step, increment or decrement depending on button pushed state
-	def timeStep(self, time):
+	def step_time(self, time):
 		if time <= 0.0:
 			raise Exception('Invalid time step')
 
@@ -84,13 +84,13 @@ class GameStarter:
 		return self.players[player_id]
 
 	#Step all players by given time
-	def timeStep(self, time):
+	def step_time(self, time):
 		time = float(time)
 		if (time <= 0.0):
 			raise Exception('time must be positive')
 
 		for pl in self.players.values():
-			pl.timeStep(time)
+			pl.step_time(time)
 		if(self.counting):
 			self.delay -= time
 		else:
@@ -138,7 +138,7 @@ def main():
 
 		#Do time calculations
 		time.sleep(0.05)
-		starter.timeStep(0.05)
+		starter.step_time(0.05)
 		totTime += 0.05
 		#Decide if game can start
 		start = starter.should_start

--- a/GameStarter/__init__.py
+++ b/GameStarter/__init__.py
@@ -101,15 +101,15 @@ def main():
 	#Visual test of GameStarter
 
 	#Set level thresholds here
-	activeLevel = 2.0
-	startLevel = 5.0
-	graceLevel = 1.0
+	total_start_delay = 5.0
+	join_delay = 2.0
+	leave_delay = 1.0
 
 	#Bar scale is number of characters that represent one second on the visualisation
 	barScale = 60
 
 	#Get an instance of GameStarter with four players
-	starter = GameStarter(4, activeLevel, startLevel, graceLevel)
+	starter = GameStarter(4, join_delay, total_start_delay, leave_delay)
 
 	#Print header for graphics
 	print()

--- a/GameStarter/__init__.py
+++ b/GameStarter/__init__.py
@@ -6,7 +6,7 @@ import time
 class GamePlayer:
 
 	#GamePlayer init
-	def __init__(self, join_delay, _unused_was_startLevel_, leave_delay):
+	def __init__(self, join_delay, leave_delay):
 		self.join_delay = float(join_delay)
 		self.leave_delay = float(leave_delay)
 		self.pushed = False
@@ -43,7 +43,7 @@ class GameStarter:
 		self.start_delay = float(total_start_delay) - float(join_delay) #FIXME Backward compatibility...
 		self.reset()
 		def newPlayer():
-			return GamePlayer(join_delay, None, leave_delay)
+			return GamePlayer(join_delay, leave_delay)
 		self.newPlayer = newPlayer
 
 	def reset(self):

--- a/GameStarter/gamestart_test.py
+++ b/GameStarter/gamestart_test.py
@@ -13,7 +13,7 @@ class TestStartButtons(unittest.TestCase):
 	def test_player_init(self):
 		#Ensure that the player can be instantiated and does sensible things
 		#Note that this class should only be instantiated by the GameStarter and so has less validity check on its inputs
-		pl = GamePlayer(1.0, 2.0, 0.5)
+		pl = GamePlayer(1.0, 0.5)
 		self.assertEqual(1.0, pl.delay)
 		self.assertFalse(pl.joined)
 		self.assertFalse(pl.pushed)
@@ -21,7 +21,7 @@ class TestStartButtons(unittest.TestCase):
 	def test_player_timing(self):
 		#Ensure that the player can be instantiated and does sensible things
 		#Note that this class should only be instantiated by the GameStarter and so has less validity check on its inputs
-		pl = GamePlayer(1.0, 2.0, 0.5)
+		pl = GamePlayer(1.0, 0.5)
 		pl.step_time(0.5)
 		self.assertFalse(pl.joined)
 		self.assertFalse(pl.pushed)
@@ -41,7 +41,7 @@ class TestStartButtons(unittest.TestCase):
 		self.assertTrue(pl.joined)
 
 	def test_player_invalid_time_step(self):
-		pl = GamePlayer(1.0, 2.0, 0.5)
+		pl = GamePlayer(1.0, 0.5)
 		invalidTimes = [0, 0.0, -1, -1.0]
 		for invalidTime in invalidTimes:
 			pl.push()

--- a/GameStarter/gamestart_test.py
+++ b/GameStarter/gamestart_test.py
@@ -51,10 +51,10 @@ class TestStartButtons(unittest.TestCase):
 
 	def test_invalid_levels(self):
 		#It is invalid to have a negative active level threshold. This should raise an exception, as should invalid types.
-		invalidInputs = [(-1.0, 2.0, 0.5), (1.0, 0.5, 0.2), (1.0, -23.0, 0.5), (2, 1, 3), (1, 0, 4), (-3, -1, -4), (None, None, None), (True, True, True), (False, True, False), ("1", "2", "7")]
+		invalidInputs = [(2.0, -1.0, 0.5), (0.5, 1.0, 0.2), (-23.0, 1.0, 0.5), (1, 2, 3), (0, 1, 4), (-1, -3, -4), (None, None, None), (True, True, True), (True, False, False), ("2", "1", "7")]
 		for invalidInput in invalidInputs:
 			try:
-				gs = GameStarter(2, *invalidInput)
+				gs = GameStarter(*invalidInput)
 				self.fail('Started with invalid levels')
 			except Exception as e:
 				pass
@@ -64,7 +64,7 @@ class TestStartButtons(unittest.TestCase):
 		invalidInputs = [-1, -1.0, -99999, "foo", "-23", "34", "12.34", None, True, False]
 		for invalidInput in invalidInputs:
 			try:
-				gs = GameStarter(2, 1.0, 2.0, 0.5)
+				gs = GameStarter(2.0, 1.0, 0.5)
 				gs.step_time(invalidInput)
 				self.fail('Invalid time step allowed')
 			except Exception as e:
@@ -73,7 +73,7 @@ class TestStartButtons(unittest.TestCase):
 	def test_total_state_correct(self):
 		testInputs = [2, 3, 4, 5, 6, 10, 999]
 		for testInput in testInputs:
-			gs = GameStarter(testInput, 1.0, 2.0, 0.5)
+			gs = GameStarter(2.0, 1.0, 0.5)
 			self.assertEqual([], gs.joined_players)
 			self.assertEqual([], gs.waiting_players)
 			self.assertFalse(gs.ready)
@@ -81,7 +81,7 @@ class TestStartButtons(unittest.TestCase):
 	def test_player_state_correct(self):
 		testInputs = [2, 3, 4, 5, 6, 10, 999]
 		for testInput in testInputs:
-			gs = GameStarter(testInput, 1.0, 2.0, 0.5)
+			gs = GameStarter(2.0, 1.0, 0.5)
 			self.assertEqual([], gs.joined_players)
 			self.assertEqual([], gs.waiting_players)
 			self.assertFalse(gs.ready)
@@ -89,7 +89,7 @@ class TestStartButtons(unittest.TestCase):
 	def test_total_state_postreset(self):
 		testInputs = [2, 3, 4, 5, 6, 10, 999]
 		for testInput in testInputs:
-			gs = GameStarter(testInput, 1.0, 2.0, 0.5)
+			gs = GameStarter(2.0, 1.0, 0.5)
 			gs.player(0).release()
 			gs.player(1).push()
 			gs.step_time(1.5)
@@ -102,7 +102,7 @@ class TestStartButtons(unittest.TestCase):
 	def test_two_player_start(self):
 		#test that two players can start a game
 		try:
-			gs = GameStarter(2, 1.0, 2.0, 0.5)
+			gs = GameStarter(2.0, 1.0, 0.5)
 		except Exception as e:
 			self.fail('Exception during __init__')
 		#Both players push
@@ -117,7 +117,7 @@ class TestStartButtons(unittest.TestCase):
 	def test_single_player_cant_start(self):
 		#test that single players cannot start a game
 		try:
-			gs = GameStarter(2, 1.0, 2.0, 0.5)
+			gs = GameStarter(2.0, 1.0, 0.5)
 		except Exception as e:
 			self.fail('Exception during __init__')
 		#One player pushes
@@ -130,7 +130,7 @@ class TestStartButtons(unittest.TestCase):
 	def test_player_can_drop_out(self):
 		#test that a player can go below active and drop out of the round start
 		try:
-			gs = GameStarter(2, 1.0, 2.0, 0.5)
+			gs = GameStarter(2.0, 1.0, 0.5)
 		except Exception as e:
 			self.fail('Exception during __init__')
 		#One player pushes
@@ -148,7 +148,7 @@ class TestStartButtons(unittest.TestCase):
 	def test_two_player_start_with_four_player_game(self):
 		#test that two players can start a game
 		try:
-			gs = GameStarter(4, 1.0, 2.0, 0.5)
+			gs = GameStarter(2.0, 1.0, 0.5)
 		except Exception as e:
 			self.fail('Exception during __init__')
 		#Both players push
@@ -163,7 +163,7 @@ class TestStartButtons(unittest.TestCase):
 	def test_button_spam_filtering(self):
 		#test that two players can start a game even when someone is button spamming
 		try:
-			gs = GameStarter(4, 1.0, 2.0, 0.5)
+			gs = GameStarter(2.0, 1.0, 0.5)
 		except Exception as e:
 			self.fail('Exception during __init__')
 		#Both players push
@@ -195,7 +195,7 @@ class TestStartButtons(unittest.TestCase):
 	def test_late_joiners(self):
 		#test that for players can start a game even when some people take a while to join in
 		try:
-			gs = GameStarter(4, 1.0, 2.0, 0.5)
+			gs = GameStarter(2.0, 1.0, 0.5)
 		except Exception as e:
 			self.fail('Exception during __init__')
 		#One players pushes
@@ -222,7 +222,7 @@ class TestStartButtons(unittest.TestCase):
 		#test that a dodgy button that flickers on and off sometimes doesn't cause problems
 		#this also simulates people who fail to keep their hand on the button persistently
 		try:
-			gs = GameStarter(2, 1.0, 20.0, 0.5) #note 20 second start time on this one
+			gs = GameStarter(20.0, 1.0, 0.5) #note 20 second start time on this one
 		except Exception as e:
 			self.fail('Exception during __init__')
 		#Both players push

--- a/GameStarter/gamestart_test.py
+++ b/GameStarter/gamestart_test.py
@@ -73,8 +73,7 @@ class TestStartButtons(unittest.TestCase):
 				gs = GameStarter(2, *invalidInput)
 				self.fail('Started with invalid levels')
 			except Exception as e:
-				errorMsg = 'GameStarter.__init__: activeLevel must be a float greater than 0, startLevel must be a float greater than activeLevel.'
-				self.assertEqual(errorMsg, str(e)[0:len(errorMsg)])
+				pass
 
 	def test_invalid_time_step(self):
 		#It is invalid to have a negative time step. This should raise an exception

--- a/GameStarter/gamestart_test.py
+++ b/GameStarter/gamestart_test.py
@@ -22,7 +22,7 @@ class TestStartButtons(unittest.TestCase):
 		#Ensure that the player can be instantiated and does sensible things
 		#Note that this class should only be instantiated by the GameStarter and so has less validity check on its inputs
 		pl = GamePlayer(1.0, 2.0, 0.5)
-		pl.timeStep(0.5)
+		pl.step_time(0.5)
 		self.assertFalse(pl.joined)
 		self.assertFalse(pl.pushed)
 		self.assertFalse(pl.waiting)
@@ -31,12 +31,12 @@ class TestStartButtons(unittest.TestCase):
 		pl.push()
 		self.assertTrue(pl.pushed)
 
-		pl.timeStep(0.51)
+		pl.step_time(0.51)
 		self.assertFalse(pl.joined)
 		self.assertTrue(pl.waiting)
 		self.assertTrue((0.4 < pl.delay) and (pl.delay < 0.5))
 
-		pl.timeStep(0.5)
+		pl.step_time(0.5)
 		self.assertFalse(pl.waiting)
 		self.assertTrue(pl.joined)
 
@@ -45,9 +45,9 @@ class TestStartButtons(unittest.TestCase):
 		invalidTimes = [0, 0.0, -1, -1.0]
 		for invalidTime in invalidTimes:
 			pl.push()
-			self.assertRaises(Exception, pl.timeStep, invalidTime)
+			self.assertRaises(Exception, pl.step_time, invalidTime)
 			pl.release()
-			self.assertRaises(Exception, pl.timeStep, invalidTime)
+			self.assertRaises(Exception, pl.step_time, invalidTime)
 
 	def test_invalid_levels(self):
 		#It is invalid to have a negative active level threshold. This should raise an exception, as should invalid types.
@@ -65,7 +65,7 @@ class TestStartButtons(unittest.TestCase):
 		for invalidInput in invalidInputs:
 			try:
 				gs = GameStarter(2, 1.0, 2.0, 0.5)
-				gs.timeStep(invalidInput)
+				gs.step_time(invalidInput)
 				self.fail('Invalid time step allowed')
 			except Exception as e:
 				pass
@@ -92,7 +92,7 @@ class TestStartButtons(unittest.TestCase):
 			gs = GameStarter(testInput, 1.0, 2.0, 0.5)
 			gs.player(0).release()
 			gs.player(1).push()
-			gs.timeStep(1.5)
+			gs.step_time(1.5)
 			self.assertEqual([1], gs.joined_players)
 			gs.resetAll()
 			self.assertEqual([], gs.joined_players)
@@ -109,7 +109,7 @@ class TestStartButtons(unittest.TestCase):
 		gs.player(0).push()
 		gs.player(1).push()
 		#Wait for three seconds
-		gs.timeStep(3.0)
+		gs.step_time(3.0)
 		#By now, should_start must be true and there should be 2 startable players
 		self.assertTrue(gs.should_start)
 		self.assertEqual(2, len(gs.joined_players))
@@ -123,7 +123,7 @@ class TestStartButtons(unittest.TestCase):
 		#One player pushes
 		gs.player(0).push()
 		#Wait for three seconds
-		gs.timeStep(3.0)
+		gs.step_time(3.0)
 		#should_start must be false
 		self.assertFalse(gs.should_start)
 
@@ -136,11 +136,11 @@ class TestStartButtons(unittest.TestCase):
 		#One player pushes
 		gs.player(0).push()
 		#Wait for three seconds
-		gs.timeStep(3.0)
+		gs.step_time(3.0)
 		#player has peaked at 2 seconds, let go of the button
 		gs.player(0).release()
 		#1.5 seconds later and they should already be out
-		gs.timeStep(1.5)
+		gs.step_time(1.5)
 		self.assertFalse(gs.player(0).joined)
 		self.assertEqual(1.0, gs.player(0).delay)
 
@@ -155,7 +155,7 @@ class TestStartButtons(unittest.TestCase):
 		gs.player(0).push()
 		gs.player(1).push()
 		#Wait for two seconds
-		gs.timeStep(2.0)
+		gs.step_time(2.0)
 		#By now, should_start must be true and there should be 2 startable players
 		self.assertTrue(gs.should_start)
 		self.assertEqual(2, len(gs.joined_players))
@@ -170,24 +170,24 @@ class TestStartButtons(unittest.TestCase):
 		gs.player(0).push()
 		gs.player(1).push()
 		#Wait for 1.5 seconds (nearly there)
-		gs.timeStep(1.5)
+		gs.step_time(1.5)
 		#player three then spams
 		gs.player(2).push()
-		gs.timeStep(0.7)
+		gs.step_time(0.7)
 		gs.player(2).release()
-		gs.timeStep(0.5)
+		gs.step_time(0.5)
 		#By now, should_start must be true and there should be 2 startable players
 		self.assertTrue(gs.should_start)
 		self.assertEqual(2, len(gs.joined_players))
 		#Do more buttom mashing to see if the filter still works after this
 		gs.player(2).push()
-		gs.timeStep(0.7)
+		gs.step_time(0.7)
 		gs.player(2).release()
-		gs.timeStep(0.5)
+		gs.step_time(0.5)
 		gs.player(2).push()
-		gs.timeStep(0.7)
+		gs.step_time(0.7)
 		gs.player(2).release()
-		gs.timeStep(0.5)
+		gs.step_time(0.5)
 		#should_start must stil be true and there should still be 2 startable players
 		self.assertTrue(gs.should_start)
 		self.assertEqual(2, len(gs.joined_players))
@@ -201,19 +201,19 @@ class TestStartButtons(unittest.TestCase):
 		#One players pushes
 		gs.player(0).push()
 		#Wait for 3 seconds (player 1 fully ready)...
-		gs.timeStep(3.0)
+		gs.step_time(3.0)
 		#Player two joins in
 		gs.player(1).push()
 		#a little later...
-		gs.timeStep(0.8)
+		gs.step_time(0.8)
 		#player three then joins
 		gs.player(2).push()
 		#later still..
-		gs.timeStep(0.7)
+		gs.step_time(0.7)
 		#player four pushes too
 		gs.player(3).push()
 		#another two seconds...
-		gs.timeStep(2.0)
+		gs.step_time(2.0)
 		#and now, should_start must be true and there should be 4 startable players
 		self.assertTrue(gs.should_start)
 		self.assertEqual(4, len(gs.joined_players))
@@ -229,28 +229,28 @@ class TestStartButtons(unittest.TestCase):
 		gs.player(0).push()
 		gs.player(1).push()
 		#Wait for 1.5 seconds (nearly there)...
-		gs.timeStep(1.5)
+		gs.step_time(1.5)
 		#Player two goes dodgy
 		gs.player(1).release()
-		gs.timeStep(0.1)
+		gs.step_time(0.1)
 		gs.player(1).push()
-		gs.timeStep(0.3)
+		gs.step_time(0.3)
 		gs.player(1).release()
-		gs.timeStep(0.2)
+		gs.step_time(0.2)
 		gs.player(1).push()
-		gs.timeStep(0.7)
+		gs.step_time(0.7)
 		gs.player(1).release()
-		gs.timeStep(0.04)
+		gs.step_time(0.04)
 		gs.player(1).push()
-		gs.timeStep(10.8)
+		gs.step_time(10.8)
 		gs.player(1).release()
-		gs.timeStep(0.2)
+		gs.step_time(0.2)
 		gs.player(1).push()
-		gs.timeStep(0.7)
+		gs.step_time(0.7)
 		gs.player(1).release()
-		gs.timeStep(0.04)
+		gs.step_time(0.04)
 		gs.player(1).push()
-		gs.timeStep(20.0) #long one to make sure
+		gs.step_time(20.0) #long one to make sure
 
 		#should_start must be true and there should be 2 startable players
 		self.assertTrue(gs.should_start)

--- a/GameStarter/gamestart_test.py
+++ b/GameStarter/gamestart_test.py
@@ -101,10 +101,8 @@ class TestStartButtons(unittest.TestCase):
 
 	def test_two_player_start(self):
 		#test that two players can start a game
-		try:
-			gs = GameStarter(2.0, 1.0, 0.5)
-		except Exception as e:
-			self.fail('Exception during __init__')
+		gs = GameStarter(2.0, 1.0, 0.5)
+
 		#Both players push
 		gs.player(0).push()
 		gs.player(1).push()
@@ -116,10 +114,8 @@ class TestStartButtons(unittest.TestCase):
 
 	def test_single_player_cant_start(self):
 		#test that single players cannot start a game
-		try:
-			gs = GameStarter(2.0, 1.0, 0.5)
-		except Exception as e:
-			self.fail('Exception during __init__')
+		gs = GameStarter(2.0, 1.0, 0.5)
+
 		#One player pushes
 		gs.player(0).push()
 		#Wait for three seconds
@@ -129,10 +125,8 @@ class TestStartButtons(unittest.TestCase):
 
 	def test_player_can_drop_out(self):
 		#test that a player can go below active and drop out of the round start
-		try:
-			gs = GameStarter(2.0, 1.0, 0.5)
-		except Exception as e:
-			self.fail('Exception during __init__')
+		gs = GameStarter(2.0, 1.0, 0.5)
+
 		#One player pushes
 		gs.player(0).push()
 		#Wait for three seconds
@@ -147,10 +141,8 @@ class TestStartButtons(unittest.TestCase):
 
 	def test_two_player_start_with_four_player_game(self):
 		#test that two players can start a game
-		try:
-			gs = GameStarter(2.0, 1.0, 0.5)
-		except Exception as e:
-			self.fail('Exception during __init__')
+		gs = GameStarter(2.0, 1.0, 0.5)
+
 		#Both players push
 		gs.player(0).push()
 		gs.player(1).push()
@@ -162,10 +154,8 @@ class TestStartButtons(unittest.TestCase):
 
 	def test_button_spam_filtering(self):
 		#test that two players can start a game even when someone is button spamming
-		try:
-			gs = GameStarter(2.0, 1.0, 0.5)
-		except Exception as e:
-			self.fail('Exception during __init__')
+		gs = GameStarter(2.0, 1.0, 0.5)
+
 		#Both players push
 		gs.player(0).push()
 		gs.player(1).push()
@@ -194,10 +184,8 @@ class TestStartButtons(unittest.TestCase):
 
 	def test_late_joiners(self):
 		#test that for players can start a game even when some people take a while to join in
-		try:
-			gs = GameStarter(2.0, 1.0, 0.5)
-		except Exception as e:
-			self.fail('Exception during __init__')
+		gs = GameStarter(2.0, 1.0, 0.5)
+
 		#One players pushes
 		gs.player(0).push()
 		#Wait for 3 seconds (player 1 fully ready)...
@@ -221,10 +209,8 @@ class TestStartButtons(unittest.TestCase):
 	def test_dodgy_button(self):
 		#test that a dodgy button that flickers on and off sometimes doesn't cause problems
 		#this also simulates people who fail to keep their hand on the button persistently
-		try:
-			gs = GameStarter(20.0, 1.0, 0.5) #note 20 second start time on this one
-		except Exception as e:
-			self.fail('Exception during __init__')
+		gs = GameStarter(20.0, 1.0, 0.5) #note 20 second start time on this one
+
 		#Both players push
 		gs.player(0).push()
 		gs.player(1).push()

--- a/GameStarter/gamestart_test.py
+++ b/GameStarter/gamestart_test.py
@@ -110,8 +110,8 @@ class TestStartButtons(unittest.TestCase):
 		gs.player(1).push()
 		#Wait for three seconds
 		gs.timeStep(3.0)
-		#By now, shouldStart must be true and there should be 2 startable players
-		self.assertTrue(gs.shouldStart())
+		#By now, should_start must be true and there should be 2 startable players
+		self.assertTrue(gs.should_start)
 		self.assertEqual(2, len(gs.joined_players))
 
 	def test_single_player_cant_start(self):
@@ -124,8 +124,8 @@ class TestStartButtons(unittest.TestCase):
 		gs.player(0).push()
 		#Wait for three seconds
 		gs.timeStep(3.0)
-		#shouldStart must be false
-		self.assertFalse(gs.shouldStart())
+		#should_start must be false
+		self.assertFalse(gs.should_start)
 
 	def test_player_can_drop_out(self):
 		#test that a player can go below active and drop out of the round start
@@ -156,8 +156,8 @@ class TestStartButtons(unittest.TestCase):
 		gs.player(1).push()
 		#Wait for two seconds
 		gs.timeStep(2.0)
-		#By now, shouldStart must be true and there should be 2 startable players
-		self.assertTrue(gs.shouldStart())
+		#By now, should_start must be true and there should be 2 startable players
+		self.assertTrue(gs.should_start)
 		self.assertEqual(2, len(gs.joined_players))
 
 	def test_button_spam_filtering(self):
@@ -176,8 +176,8 @@ class TestStartButtons(unittest.TestCase):
 		gs.timeStep(0.7)
 		gs.player(2).release()
 		gs.timeStep(0.5)
-		#By now, shouldStart must be true and there should be 2 startable players
-		self.assertTrue(gs.shouldStart())
+		#By now, should_start must be true and there should be 2 startable players
+		self.assertTrue(gs.should_start)
 		self.assertEqual(2, len(gs.joined_players))
 		#Do more buttom mashing to see if the filter still works after this
 		gs.player(2).push()
@@ -188,8 +188,8 @@ class TestStartButtons(unittest.TestCase):
 		gs.timeStep(0.7)
 		gs.player(2).release()
 		gs.timeStep(0.5)
-		#shouldStart must stil be true and there should still be 2 startable players
-		self.assertTrue(gs.shouldStart())
+		#should_start must stil be true and there should still be 2 startable players
+		self.assertTrue(gs.should_start)
 		self.assertEqual(2, len(gs.joined_players))
 
 	def test_late_joiners(self):
@@ -214,8 +214,8 @@ class TestStartButtons(unittest.TestCase):
 		gs.player(3).push()
 		#another two seconds...
 		gs.timeStep(2.0)
-		#and now, shouldStart must be true and there should be 4 startable players
-		self.assertTrue(gs.shouldStart())
+		#and now, should_start must be true and there should be 4 startable players
+		self.assertTrue(gs.should_start)
 		self.assertEqual(4, len(gs.joined_players))
 
 	def test_dodgy_button(self):
@@ -252,8 +252,8 @@ class TestStartButtons(unittest.TestCase):
 		gs.player(1).push()
 		gs.timeStep(20.0) #long one to make sure
 
-		#shouldStart must be true and there should be 2 startable players
-		self.assertTrue(gs.shouldStart())
+		#should_start must be true and there should be 2 startable players
+		self.assertTrue(gs.should_start)
 		self.assertEqual(2, len(gs.joined_players))
 
 	def test_main_run(self):

--- a/GameStarter/gamestart_test.py
+++ b/GameStarter/gamestart_test.py
@@ -110,24 +110,31 @@ class TestStartButtons(unittest.TestCase):
 		testInputs = [2, 3, 4, 5, 6, 10, 999]
 		for testInput in testInputs:
 			gs = GameStarter(testInput, 1.0, 2.0, 0.5)
-			self.assertEqual(testInput, gs.totalInState("OUT"))
+			self.assertEqual(0, gs.totalInState("ACTIVE"))
+			self.assertEqual(0, gs.totalInState("WAIT"))
+			self.assertEqual(0, gs.totalInState("START"))
 
 	def test_player_state_correct(self):
 		testInputs = [2, 3, 4, 5, 6, 10, 999]
 		for testInput in testInputs:
 			gs = GameStarter(testInput, 1.0, 2.0, 0.5)
-			self.assertEqual(list(range(testInput)), sorted(gs.playersInState("OUT")))
+			self.assertEqual(0, gs.totalInState("ACTIVE"))
+			self.assertEqual(0, gs.totalInState("WAIT"))
+			self.assertEqual(0, gs.totalInState("START"))
 
 	def test_total_state_postreset(self):
 		testInputs = [2, 3, 4, 5, 6, 10, 999]
 		for testInput in testInputs:
 			gs = GameStarter(testInput, 1.0, 2.0, 0.5)
+			gs.release(0)
 			gs.push(1)
 			gs.timeStep(1.5)
 			self.assertEqual(1, gs.totalInState("ACTIVE"))
-			self.assertEqual(testInput-1, gs.totalInState("OUT"))
+			self.assertEqual(1, gs.totalInState("OUT"))
 			gs.resetAll()
-			self.assertEqual(testInput, gs.totalInState("OUT"))
+			self.assertEqual(0, gs.totalInState("ACTIVE"))
+			self.assertEqual(0, gs.totalInState("WAIT"))
+			self.assertEqual(0, gs.totalInState("START"))
 
 	def test_two_player_start(self):
 		#test that two players can start a game
@@ -285,10 +292,10 @@ class TestStartButtons(unittest.TestCase):
 		#shouldStart must be true and there should be 2 startable players
 		self.assertTrue(gs.shouldStart())
 		self.assertEqual(2, gs.totalStartablePlayers())
-		
+
 	def test_main_run(self):
 		main()
-		
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/GameStarter/gamestart_test.py
+++ b/GameStarter/gamestart_test.py
@@ -94,7 +94,7 @@ class TestStartButtons(unittest.TestCase):
 			gs.player(1).push()
 			gs.step_time(1.5)
 			self.assertEqual([1], gs.joined_players)
-			gs.resetAll()
+			gs.reset()
 			self.assertEqual([], gs.joined_players)
 			self.assertEqual([], gs.waiting_players)
 			self.assertFalse(gs.ready)

--- a/GameStarter/gamestart_test.py
+++ b/GameStarter/gamestart_test.py
@@ -65,17 +65,6 @@ class TestStartButtons(unittest.TestCase):
 			pl.pushed = False
 			self.assertRaises(Exception, pl.timeStep, invalidTime)
 
-	def test_invalid_players(self):
-		#It is invalid to have only one player. This should raise an exception. As should a negative number.
-		invalidInputs = [1, 0, -1, None, False, True, "2", "foo"]
-		for invalidInput in invalidInputs:
-			try:
-				gs = GameStarter(invalidInput, 1.0, 2.0, 0.5)
-				self.fail('Started with 1 player')
-			except Exception as e:
-				errorMsg = 'GameStarter.__init__: maxPlayers must be an integer greater than 2 (At least two players are required).'
-				self.assertEqual(errorMsg, str(e)[0:len(errorMsg)])
-
 	def test_invalid_levels(self):
 		#It is invalid to have a negative active level threshold. This should raise an exception, as should invalid types.
 		invalidInputs = [(-1.0, 2.0, 0.5), (1.0, 0.5, 0.2), (1.0, -23.0, 0.5), (2, 1, 3), (1, 0, 4), (-3, -1, -4), (None, None, None), (True, True, True), (False, True, False), ("1", "2", "7")]

--- a/GameStarter/gamestart_test.py
+++ b/GameStarter/gamestart_test.py
@@ -126,7 +126,7 @@ class TestStartButtons(unittest.TestCase):
 		gs.timeStep(3.0)
 		#By now, shouldStart must be true and there should be 2 startable players
 		self.assertTrue(gs.shouldStart())
-		self.assertEqual(2, gs.totalStartablePlayers())
+		self.assertEqual(2, gs.totalInState('START'))
 
 	def test_single_player_cant_start(self):
 		#test that single players cannot start a game
@@ -172,7 +172,7 @@ class TestStartButtons(unittest.TestCase):
 		gs.timeStep(2.0)
 		#By now, shouldStart must be true and there should be 2 startable players
 		self.assertTrue(gs.shouldStart())
-		self.assertEqual(2, gs.totalStartablePlayers())
+		self.assertEqual(2, gs.totalInState('START'))
 
 	def test_button_spam_filtering(self):
 		#test that two players can start a game even when someone is button spamming
@@ -192,7 +192,7 @@ class TestStartButtons(unittest.TestCase):
 		gs.timeStep(0.5)
 		#By now, shouldStart must be true and there should be 2 startable players
 		self.assertTrue(gs.shouldStart())
-		self.assertEqual(2, gs.totalStartablePlayers())
+		self.assertEqual(2, gs.totalInState('START'))
 		#Do more buttom mashing to see if the filter still works after this
 		gs.push(2)
 		gs.timeStep(0.7)
@@ -204,7 +204,7 @@ class TestStartButtons(unittest.TestCase):
 		gs.timeStep(0.5)
 		#shouldStart must stil be true and there should still be 2 startable players
 		self.assertTrue(gs.shouldStart())
-		self.assertEqual(2, gs.totalStartablePlayers())
+		self.assertEqual(2, gs.totalInState('START'))
 
 	def test_late_joiners(self):
 		#test that for players can start a game even when some people take a while to join in
@@ -230,7 +230,7 @@ class TestStartButtons(unittest.TestCase):
 		gs.timeStep(2.0)
 		#and now, shouldStart must be true and there should be 4 startable players
 		self.assertTrue(gs.shouldStart())
-		self.assertEqual(4, gs.totalStartablePlayers())
+		self.assertEqual(4, gs.totalInState('START'))
 
 	def test_dodgy_button(self):
 		#test that a dodgy button that flickers on and off sometimes doesn't cause problems
@@ -268,7 +268,7 @@ class TestStartButtons(unittest.TestCase):
 
 		#shouldStart must be true and there should be 2 startable players
 		self.assertTrue(gs.shouldStart())
-		self.assertEqual(2, gs.totalStartablePlayers())
+		self.assertEqual(2, gs.totalInState('START'))
 
 	def test_main_run(self):
 		main()

--- a/GameStarter/gamestart_test.py
+++ b/GameStarter/gamestart_test.py
@@ -18,17 +18,6 @@ class TestStartButtons(unittest.TestCase):
 		self.assertEqual("OUT", pl.state)
 		self.assertEqual(False, pl.pushed)
 
-	def test_player_reset(self):
-		#Ensure that the player can be reset
-		#Note that this class should only be instantiated by the GameStarter and so has less validity check on its inputs
-		pl = GamePlayer(1.0, 2.0, 0.5)
-		pl.pushed = True
-		pl.timeStep(5.0)
-		pl.reset()
-		self.assertEqual(0.0, pl.level)
-		self.assertEqual("OUT", pl.state)
-		self.assertEqual(False, pl.pushed)
-
 	def test_player_timing(self):
 		#Ensure that the player can be instantiated and does sensible things
 		#Note that this class should only be instantiated by the GameStarter and so has less validity check on its inputs

--- a/README.md
+++ b/README.md
@@ -21,28 +21,21 @@ To use this code:
 
 - then report whenever a player pushes or releases a button:
 ```python
-	gs.push(0)	#report button push for first player
-	gs.release(1)	#report button release for second player
+	gs.player(0).push()	#report button push for first player
+	gs.player(1).release()	#report button release for second player
 ```
 
 - regularly update the internal timer at the desired resolution:
 ```python
-	gs.timeStep(0.05) #Step 0.05 seconds, call this every 0.05 seconds (for example)
+	gs.step_time(0.05) #Step 0.05 seconds, call this every 0.05 seconds (for example)
 ```
 
 - then you can see if you have enough players ready like so:
 ```python
-	if gs.shouldStart() : #we have enough players to start
+	if gs.should_start : #we have enough players to start
 ```
 
-- you can get an exact number with this:
+- you can determine which players have joined using:
 ```python
-	gs.totalStartablePlayers()
-```
-
-- and you can loop through all players to see if each one is joining in:
-```python
-	for i in range(4):
-		if gs.isStartablePlayer(i):
-			#add player i to game
+	gs.joined_players
 ```

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ To use this code:
 
 - instantiate the `GameStarter` class
 ```python
-	gs = GameStarter(max players, activation threshold, start threshold, grace time)
+	gs = GameStarter(total start delay, delay to join game, delay to leave game)
 	#eg...
-	gs = GameStarter(4, 2.0, 5.0, 0.5)
+	gs = GameStarter(5.0, 2.0, 0.5)
 ```
 
 - then report whenever a player pushes or releases a button:
@@ -46,4 +46,3 @@ To use this code:
 		if gs.isStartablePlayer(i):
 			#add player i to game
 ```
-

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     print(setuptools.find_packages())
 setuptools.setup(
     name="game-starter",
-    version="1.0.1",
+    version="2.0.0",
     author="Daniel Bailey",
     author_email="danieljabailey@gmail.com",
     description="Decides when to start a game, based on who's holding a button.",


### PR DESCRIPTION
I've replaced the game starting logic with a pair of state machines with simple delays.  This should make the behaviour a lot easier to understand.

There are a couple of interface changes; I kept shouldStart because that's an easy interface (though the name case is non-stylistic), but .push(n) and .release(n) have been replaced by .player(n).push() etc to avoid having a load of delegation functions; isStartablePlayer is no longer present, just use gs.joined_players to get the appropriate list of ids when they're needed.